### PR TITLE
Ignore .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "automatic"
-}


### PR DESCRIPTION
The `.vscode/` folder has to be considered like a user settings folder, it should be ignored.